### PR TITLE
AMI Lookup

### DIFF
--- a/playbook_create_peer_network.yml
+++ b/playbook_create_peer_network.yml
@@ -15,8 +15,6 @@
           - aws_region is defined
           - dmz_ssh_key_name is defined
           - priv_network_ssh_key_name is defined
-          - dmz_instance_ami is defined
-          - priv_network_instance_type is defined
         fail_msg: "Required variables not set"
 
     - name: Create Peer Networking Model

--- a/roles/manage_direct_peered_networks/README.md
+++ b/roles/manage_direct_peered_networks/README.md
@@ -29,10 +29,14 @@ vpc_priv_net_priv_subnet_cidr: 10.0.0.0/24
 vpc_dmz_cidr: 10.1.0.0/16
 vpc_dmz_subnet1_cidr: 10.1.0.0/24
 dmz_instance_type: t2.micro
-dmz_instance_ami: ami-06640050dc3f556bb
+dmz_instance_ami_owner: "{{ default(omit) }}"
+dmz_instance_ami_architecture: x86_64
+dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
 dmz_instance_name: dmz-ssh-tunnel-vm
 priv_network_instance_type: t2.micro
-priv_network_instance_ami: ami-06640050dc3f556bb
+priv_network_instance_ami_owner: "{{ default(omit) }}"
+priv_network_instance_ami_architecture: x86_64
+priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
 priv_network_instance_name: priv-network-vm
 ```
 

--- a/roles/manage_direct_peered_networks/README.md
+++ b/roles/manage_direct_peered_networks/README.md
@@ -29,12 +29,13 @@ vpc_priv_net_priv_subnet_cidr: 10.0.0.0/24
 vpc_dmz_cidr: 10.1.0.0/16
 vpc_dmz_subnet1_cidr: 10.1.0.0/24
 dmz_instance_type: t2.micro
-dmz_instance_ami_owner: "{{ default(omit) }}"
+dmz_instance_ami_owner: "{{ omit }}"
 dmz_instance_ami_architecture: x86_64
 dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
+dmz_instance_ami: undef # use this variable to override the AMI lookup
 dmz_instance_name: dmz-ssh-tunnel-vm
 priv_network_instance_type: t2.micro
-priv_network_instance_ami_owner: "{{ default(omit) }}"
+priv_network_instance_ami_owner: "{{ omit }}"
 priv_network_instance_ami_architecture: x86_64
 priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
 priv_network_instance_name: priv-network-vm

--- a/roles/manage_direct_peered_networks/defaults/main.yml
+++ b/roles/manage_direct_peered_networks/defaults/main.yml
@@ -7,8 +7,12 @@ vpc_priv_net_hosts_pattern: 10.0.*
 vpc_dmz_cidr: 10.1.0.0/16
 vpc_dmz_subnet1_cidr: 10.1.0.0/24
 dmz_instance_type: t2.micro
-dmz_instance_ami: ami-06640050dc3f556bb # ami-0cff7528ff583bf9a
+dmz_instance_ami_owner: "{{ default(omit) }}"
+dmz_instance_ami_architecture: x86_64
+dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
 dmz_instance_name: dmz-ssh-tunnel-vm
 priv_network_instance_type: t2.micro
-priv_network_instance_ami: ami-06640050dc3f556bb
+priv_network_instance_ami_owner: "{{default(omit) }}"
+priv_network_instance_ami_architecture: x86_64
+priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
 priv_network_instance_name: priv-network-vm

--- a/roles/manage_direct_peered_networks/defaults/main.yml
+++ b/roles/manage_direct_peered_networks/defaults/main.yml
@@ -7,12 +7,14 @@ vpc_priv_net_hosts_pattern: 10.0.*
 vpc_dmz_cidr: 10.1.0.0/16
 vpc_dmz_subnet1_cidr: 10.1.0.0/24
 dmz_instance_type: t2.micro
-dmz_instance_ami_owner: "{{ default(omit) }}"
+dmz_instance_ami_owner: "{{ omit }}"
 dmz_instance_ami_architecture: x86_64
 dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
+dmz_instance_ami: undef
 dmz_instance_name: dmz-ssh-tunnel-vm
 priv_network_instance_type: t2.micro
-priv_network_instance_ami_owner: "{{default(omit) }}"
+priv_network_instance_ami_owner: "{{ omit }}"
 priv_network_instance_ami_architecture: x86_64
 priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
+priv_network_instance_ami: undef
 priv_network_instance_name: priv-network-vm

--- a/roles/manage_direct_peered_networks/defaults/main.yml
+++ b/roles/manage_direct_peered_networks/defaults/main.yml
@@ -10,11 +10,11 @@ dmz_instance_type: t2.micro
 dmz_instance_ami_owner: "{{ omit }}"
 dmz_instance_ami_architecture: x86_64
 dmz_instance_ami_filter: RHEL-8*HVM-*Hourly*
-dmz_instance_ami: undef
+#dmz_instance_ami: undef
 dmz_instance_name: dmz-ssh-tunnel-vm
 priv_network_instance_type: t2.micro
 priv_network_instance_ami_owner: "{{ omit }}"
 priv_network_instance_ami_architecture: x86_64
 priv_network_instance_ami_filter: RHEL-8*HVM-*Hourly*
-priv_network_instance_ami: undef
+#priv_network_instance_ami: undef
 priv_network_instance_name: priv-network-vm

--- a/roles/manage_direct_peered_networks/tasks/create.yml
+++ b/roles/manage_direct_peered_networks/tasks/create.yml
@@ -291,7 +291,7 @@
     - name: Select DMZ instance ami
       set_fact:
         dmz_instance_ami: >
-          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
+          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim }}
       when: dmz_instance_ami is not defined
 
     - name: Provision an SSH tunnel VM in the DMZ
@@ -387,7 +387,7 @@
     - name: Select private network instance ami
       set_fact:
         priv_network_instance_ami: >
-          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
+          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim}}
       when: priv_network_instance_ami is not defined
 
     - name: Provision a test VM in the private network

--- a/roles/manage_direct_peered_networks/tasks/create.yml
+++ b/roles/manage_direct_peered_networks/tasks/create.yml
@@ -286,11 +286,13 @@
           name: "{{ dmz_instance_ami_filter }}"
           architecture: "{{ dmz_instance_ami_architecture }}"
       register: dmz_amis
+      when: dmz_instance_ami is not defined
 
     - name: Select DMZ instance ami
       set_fact:
         dmz_instance_ami: >
           {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1] }}
+      when: dmz_instance_ami is not defined
 
     - name: Provision an SSH tunnel VM in the DMZ
       amazon.aws.ec2_instance:
@@ -380,11 +382,13 @@
           name: "{{ priv_network_instance_ami_filter }}"
           architecture: "{{ priv_network_instance_ami_architecture }}"
       register: private_network_amis
+      when: priv_network_instance_ami is not defined
 
     - name: Select private network instance ami
       set_fact:
         priv_network_instance_ami: >
           {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1] }}
+      when: priv_network_instance_ami is not defined
 
     - name: Provision a test VM in the private network
       amazon.aws.ec2_instance:

--- a/roles/manage_direct_peered_networks/tasks/create.yml
+++ b/roles/manage_direct_peered_networks/tasks/create.yml
@@ -291,7 +291,7 @@
     - name: Select DMZ instance ami
       set_fact:
         dmz_instance_ami: >
-          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1] }}
+          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: dmz_instance_ami is not defined
 
     - name: Provision an SSH tunnel VM in the DMZ
@@ -387,7 +387,7 @@
     - name: Select private network instance ami
       set_fact:
         priv_network_instance_ami: >
-          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1] }}
+          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: priv_network_instance_ami is not defined
 
     - name: Provision a test VM in the private network

--- a/roles/manage_direct_peered_networks/tasks/create.yml
+++ b/roles/manage_direct_peered_networks/tasks/create.yml
@@ -278,6 +278,20 @@
           - DMZ
       when: existing_dmz_instance.instances is defined and existing_dmz_instance.instances | length > 0
 
+    - name: Lookup DMZ instance ami 
+      amazon.aws.ec2_ami_info:
+        region: "{{ aws_region }}"
+        owners: "{{ dmz_instance_ami_owner }}"
+        filters:
+          name: "{{ dmz_instance_ami_filter }}"
+          architecture: "{{ dmz_instance_ami_architecture }}"
+      register: dmz_amis
+
+    - name: Select DMZ instance ami
+      set_fact:
+        dmz_instance_ami: >
+          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1] }}
+
     - name: Provision an SSH tunnel VM in the DMZ
       amazon.aws.ec2_instance:
         count: 1
@@ -357,6 +371,20 @@
         groups:
           - private
       when: existing_priv_network_instance.instances is defined and existing_priv_network_instance.instances | length > 0
+
+    - name: Lookup private network instance ami 
+      amazon.aws.ec2_ami_info:
+        region: "{{ aws_region }}"
+        owners: "{{ priv_network_instance_ami_owner }}"
+        filters:
+          name: "{{ priv_network_instance_ami_filter }}"
+          architecture: "{{ priv_network_instance_ami_architecture }}"
+      register: private_network_amis
+
+    - name: Select private network instance ami
+      set_fact:
+        priv_network_instance_ami: >
+          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1] }}
 
     - name: Provision a test VM in the private network
       amazon.aws.ec2_instance:

--- a/roles/manage_direct_peered_networks/tasks/create.yml
+++ b/roles/manage_direct_peered_networks/tasks/create.yml
@@ -291,14 +291,14 @@
     - name: Select DMZ instance ami
       set_fact:
         dmz_instance_ami: >
-          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim }}
+          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: dmz_instance_ami is not defined
 
     - name: Provision an SSH tunnel VM in the DMZ
       amazon.aws.ec2_instance:
         count: 1
         image:
-          id: "{{ dmz_instance_ami }}"
+          id: "{{ dmz_instance_ami | trim }}"
         instance_type: "{{ dmz_instance_type }}"
         key_name: "{{ dmz_ssh_key_name }}"
         name: "{{ dmz_instance_name }}"
@@ -387,14 +387,14 @@
     - name: Select private network instance ami
       set_fact:
         priv_network_instance_ami: >
-          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim}}
+          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: priv_network_instance_ami is not defined
 
     - name: Provision a test VM in the private network
       amazon.aws.ec2_instance:
         count: 1
         image:
-          id: "{{ priv_network_instance_ami }}"
+          id: "{{ priv_network_instance_ami  | trim }}"
         instance_type: "{{ priv_network_instance_type }}"
         key_name: "{{ priv_network_ssh_key_name }}"
         name: "{{ priv_network_instance_name }}"


### PR DESCRIPTION
The current implementation requires knowing the AMI ID in a given region to run successfully. This change allows the user to specify a set of filter conditions to select an AMI in the region being used.