### PR TITLE
Create VM Role

### DIFF
--- a/playbook_create_vm.yml
+++ b/playbook_create_vm.yml
@@ -14,6 +14,6 @@
           - aws_instance_size is defined
         fail_msg: "Required variables not set"
 
-    - name: include create vm role
-      include_role:
+    - name: Include create vm role
+      ansible.builtin.include_role:
         name: create_vm

--- a/playbook_create_vm.yml
+++ b/playbook_create_vm.yml
@@ -4,82 +4,16 @@
   connection: local
   gather_facts: false
   vars_files:
-    - vars/create_vm.yml
+    - "vm_blueprints/{{vm_blueprint}}.yml"
   tasks:
     - name: Fail if variables not defined
       ansible.builtin.assert:
         that:
-          - tenancy is defined
           - aws_region is defined
-          - vm_ami is defined
-          - security_group_id is defined
-          - ssh_key_name is defined
-          - vpc_subnet_id is defined
-          - security_group_id is defined
+          - aws_keypair_name is defined
+          - aws_instance_size is defined
         fail_msg: "Required variables not set"
 
-    - name: Check if a demo VM is already provisioned
-      amazon.aws.ec2_instance_info:
-        filters:
-          "tag:deployment": ansible
-          "tag:purpose": create-vm-demo
-          "tag:ansible-role": none
-          "tag:ansible-collection": aws.infrastructure_config_demos
-          instance-state-name:
-            - pending
-            - running
-            - shutting-down
-            - stopping
-            - stopped
-        region: "{{ aws_region }}"
-      register: existing_vm
-
-    - name: Output the IP of existing VM
-      ansible.builtin.debug:
-        msg: "Public IP for new instance: {{ existing_vm.instances[0].public_ip_address }}"
-      when: existing_vm.instances is defined and existing_vm.instances | length > 0
-
-    - name: Set stats for Controller of existing VM
-      ansible.builtin.set_stats:
-        data:
-          priv_network_private_ip: "{{ existing_vm.instances[0].private_ip_address }}"
-          public_ip: "{{ existing_vm.instances[0].public_ip_address }}"
-      when: existing_vm.instances is defined and existing_vm.instances | length > 0
-
-    - name: Provision a test VM
-      amazon.aws.ec2_instance:
-        count: 1
-        image:
-          id: "{{ vm_ami }}"
-        instance_type: "{{ instance_type }}"
-        key_name: "{{ ssh_key_name }}"
-        name: "{{ instance_name | default('create_vm_test') }}"
-        network:
-          assign_public_ip: "{{ public_ip | default(True) }}"
-          delete_on_termination: true
-        region: "{{ aws_region }}"
-        security_groups:
-          - "{{ security_group_id }}"
-        state: running
-        tags:
-          deployment: ansible
-          purpose: create-vm-demo
-          ansible-role: none
-          ansible-collection: aws.infrastructure_config_demos
-        tenancy: "{{ tenancy }}" # noqa args[module]
-        vpc_subnet_id: "{{ vpc_subnet_id }}"
-        wait: true
-      register: new_ec2_instance
-      when: existing_vm.instances is defined and existing_vm.instances | length == 0
-
-    - name: Output the IP of new VM
-      ansible.builtin.debug:
-        msg: "Public IP for new instance: {{ new_ec2_instance.instances[0].public_ip_address }}"
-      when: new_ec2_instance.instances is defined and new_ec2_instance.instances | length > 0
-
-    - name: Set stats for Controller of new VM
-      ansible.builtin.set_stats:
-        data:
-          priv_network_private_ip: "{{ new_ec2_instance.instances[0].private_ip_address }}"
-          public_ip: "{{ new_ec2_instance.instances[0].public_ip_address }}"
-      when: new_ec2_instance.instances is defined and new_ec2_instance.instances | length > 0
+    - name: include create vm role
+      include_role:
+        name: create_vm

--- a/playbook_delete_inventory_vm.yml
+++ b/playbook_delete_inventory_vm.yml
@@ -1,23 +1,21 @@
 ---
 - name: Delete VM from AWS dynamic inventory
-  hosts: "{{ HOSTS }}"
+  hosts: "{{ _hosts | default(omit) }}"
   gather_facts: false
-  vars:
-    HOSTS: undef
 
   tasks:
-  - name: list systems to be destroyed
-    ansible.builtin.debug:
-      msg: "{{ inventory_hostname }}"
+    - name: List systems to be destroyed
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }}"
 
-  - name: pause for review...
-    ansible.builtin.pause:
-      seconds: 30
-      prompt: "Systems listed above will be DESTROYED in 30 seconds. Cancel the job to Abort."
+    - name: Pause for review...
+      ansible.builtin.pause:
+        seconds: 30
+        prompt: "Systems listed above will be DESTROYED in 30 seconds. Cancel the job to Abort."
 
-  - name: Destroy VM
-    amazon.aws.ec2_instance:
-      state: absent
-      instance_ids: "{{ instance_id }}"
-      region: "{{ placement.region }}"
-    delegate_to: localhost
+    - name: Destroy VM
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ instance_id }}"
+        region: "{{ placement.region }}"
+      delegate_to: localhost

--- a/playbook_delete_inventory_vm.yml
+++ b/playbook_delete_inventory_vm.yml
@@ -1,0 +1,23 @@
+---
+- name: Delete VM from AWS dynamic inventory
+  hosts: "{{ HOSTS }}"
+  gather_facts: false
+  vars:
+    HOSTS: undef
+
+  tasks:
+  - name: list systems to be destroyed
+    ansible.builtin.debug:
+      msg: "{{ inventory_hostname }}"
+
+  - name: pause for review...
+    ansible.builtin.pause:
+      seconds: 30
+      prompt: "Systems listed above will be DESTROYED in 30 seconds. Cancel the job to Abort."
+
+  - name: Destroy VM
+    amazon.aws.ec2_instance:
+      state: absent
+      instance_ids: "{{ instance_id }}"
+      region: "{{ placement.region }}"
+    delegate_to: localhost

--- a/roles/create_vm/README.md
+++ b/roles/create_vm/README.md
@@ -1,0 +1,60 @@
+# Create VM Role
+
+This Ansible role contains repeatable steps to provision new VMs into an existing VPC subnet. This operation works off a series of default variables that can be overridden from the calling playbook.
+
+## Variables
+
+The following variables are defined as defaults and are intended to be overridden by the user for different VM deployments.
+
+### Required
+```yaml
+---
+aws_region: us-east-1 # The region in which the resources are deployed
+aws_keypair_name:  aws-test-key ## The AWS SSH key to use when configuring access to the EC2 instances
+aws_instance_size: t2.micro # The instance size to deploy
+
+## AMI Lookup - These variables are used to select the AMI to deploy
+aws_image_filter: 'RHEL-8*HVM-*Hourly*' # The filter string used to search for an AMI
+aws_image_owners: 309956199498 # (optional) Used for private AMIs such as Red Hat Cloud Access
+aws_image_architecture: x86_64 # (optional) Used as required by the AMI and filter criteria
+# aws_instance_ami: undef (optional) Used to override the filter parameters and explicitly identify an AMI
+
+## Tag Defaults - These variables are the default tags for the created instance
+vm_name: demo_vm
+vm_deployment: default
+vm_environment: default
+vm_owner: ansible
+vm_purpose: demo
+```
+
+### Other Variables
+```yaml
+tenancy: default
+aws_securitygroup_name: private-network-sg # Name of security group to associate with the new VM
+aws_vpc_subnet_name: priv-net-private-subnet # Name of the subnet to build the new VM
+aws_ec2_wait: true # wait for confirmation that the instance has been created before proceeding
+aws_userdata_template: default # userdata template to use for VM creation. default == empty userdata script
+```
+
+## Example Playbook
+```yaml
+---
+- name: Create VM Demo
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - "vm_blueprints/{{vm_blueprint}}.yml" #override variables here
+  tasks:
+    - name: Fail if variables not defined
+      ansible.builtin.assert:
+        that:
+          - aws_region is defined
+          - aws_keypair_name is defined
+          - aws_instance_size is defined
+        fail_msg: "Required variables not set"
+
+    - name: include create vm role
+      include_role:
+        name: create_vm
+```

--- a/roles/create_vm/defaults/main.yml
+++ b/roles/create_vm/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+aws_region: us-east-1
+aws_keypair_name: aws-test-key
+aws_instance_size: t2.micro
+tenancy: default
+aws_securitygroup_name: private-network-sg
+aws_vpc_subnet_name: priv-net-private-subnet
+aws_ec2_wait: true
+aws_userdata_template: default
+# Tag Defaults
+vm_name: demo_vm
+vm_deployment: default
+vm_environment: default
+vm_owner: ansible
+vm_purpose: demo
+#AMI Lookup
+aws_image_owners: 309956199498
+aws_image_filter: 'RHEL-8*HVM-*Hourly*'
+aws_image_architecture: x86_64

--- a/roles/create_vm/defaults/main.yml
+++ b/roles/create_vm/defaults/main.yml
@@ -13,7 +13,7 @@ vm_deployment: default
 vm_environment: default
 vm_owner: ansible
 vm_purpose: demo
-#AMI Lookup
+# AMI Lookup
 aws_image_owners: 309956199498
 aws_image_filter: 'RHEL-8*HVM-*Hourly*'
 aws_image_architecture: x86_64

--- a/roles/create_vm/tasks/main.yml
+++ b/roles/create_vm/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Check if the VM is already provisioned
   amazon.aws.ec2_instance_info:
     filters:
@@ -22,9 +21,9 @@
 
 - name: Output the IP of existing VM
   ansible.builtin.debug:
-    msg: 
-     - "Public IP for new instance: {{ existing_vm.instances[0].public_ip_address }}"
-     - "Private IP for new instance: {{ existing_vm.instances[0].private_ip_address }}"
+    msg:
+      - "Public IP for new instance: {{ existing_vm.instances[0].public_ip_address }}"
+      - "Private IP for new instance: {{ existing_vm.instances[0].private_ip_address }}"
   when: existing_vm.instances is defined and existing_vm.instances | length > 0
 
 - name: Set stats for Controller of existing VM
@@ -34,74 +33,75 @@
       public_ip: "{{ existing_vm.instances[0].public_ip_address }}"
   when: existing_vm.instances is defined and existing_vm.instances | length > 0
 
-- block:
-  - name: Get subnet info
-    amazon.aws.ec2_vpc_subnet_info:
-      region: "{{ aws_region }}"
-      filters:
-        "tag:Name": "{{ aws_vpc_subnet_name }}"
-    register: aws_subnet
-    when: aws_subnet_id is not defined
-  
-  - name: Save subnet id
-    set_fact:
-      aws_subnet_id: "{{ aws_subnet.subnets|map(attribute='id')| list | last }}"
-    when: aws_subnet_id is not defined
-  
-  - name: Find ami
-    amazon.aws.ec2_ami_info:
-      region: "{{ aws_region }}"
-      owners: "{{ aws_image_owners | default(omit)}}"
-      filters:
-        name: "{{ aws_image_filter }}"
-        architecture: "{{ aws_image_architecture | default(omit) }}"
-    register: vm_amis
-    when: aws_instance_ami is not defined
-  
-  - name: Save ami
-    set_fact:
-      aws_instance_ami: >
-        {{ (vm_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
-    when: aws_instance_ami is not defined
-
-  - name: Create instance
-    amazon.aws.ec2_instance:
-      filters:
-        "tag:Name": "{{ vm_name }}"
-      network:
-        assign_public_ip: yes
-        delete_on_termination: true
-      tenancy: "{{ tenancy }}"
-      key_name: "{{ aws_keypair_name }}"
-      instance_type: "{{ aws_instance_size }}"
-      image_id: "{{ aws_instance_ami | trim }}"
-      region: "{{ aws_region }}"
-      security_group: "{{ aws_securitygroup_name }}"
-      tags:
-        Name: "{{ vm_name }}"
-        blueprint: "{{ vm_blueprint }}"
-        environment: "{{ vm_environment }}"
-        deployment: "{{ vm_deployment }}"
-        owner: "{{ vm_owner }}"
-        purpose: "{{ vm_purpose }}"
-        ansible-role: create_vm
-        ansible-collection: aws.infrastructure_config_demos
-      wait: "{{ aws_ec2_wait }}"
-      vpc_subnet_id: "{{ aws_subnet_id }}"
-      user_data: "{{ lookup('template', aws_userdata_template+'.j2', template_vars=dict(vm_name=vm_name)) }}"
-    register: aws_ec2_instance
-
-  - name: Output the IP of new VM
-    ansible.builtin.debug:
-      msg:
-        - "Public IP for new instance: {{ aws_ec2_instance.instances[0].public_ip_address | default('') }}"
-        - "Private IP for new instance: {{ aws_ec2_instance.instances[0].private_ip_address | default('') }}"
-    when: aws_ec2_instance.instances is defined and aws_ec2_instance.instances | length > 0
-
-  - name: Set stats for Controller of new VM
-    ansible.builtin.set_stats:
-      data:
-        priv_network_private_ip: "{{ aws_ec2_instance.instances[0].private_ip_address | default('') }}"
-        public_ip: "{{ aws_ec2_instance.instances[0].public_ip_address | default('') }}"
-    when: aws_ec2_instance.instances is defined and aws_ec2_instance.instances | length > 0
+- name: Create Instance
   when: existing_vm.instances | length == 0
+  block:
+    - name: Get subnet info
+      amazon.aws.ec2_vpc_subnet_info:
+        region: "{{ aws_region }}"
+        filters:
+          "tag:Name": "{{ aws_vpc_subnet_name }}"
+      register: aws_subnet
+      when: aws_subnet_id is not defined
+
+    - name: Save subnet id
+      ansible.builtin.set_fact:
+        aws_subnet_id: "{{ aws_subnet.subnets | map(attribute='id') | list | last }}"
+      when: aws_subnet_id is not defined
+
+    - name: Find ami
+      amazon.aws.ec2_ami_info:
+        region: "{{ aws_region }}"
+        owners: "{{ aws_image_owners | default(omit) }}"
+        filters:
+          name: "{{ aws_image_filter }}"
+          architecture: "{{ aws_image_architecture | default(omit) }}"
+      register: vm_amis
+      when: aws_instance_ami is not defined
+
+    - name: Save ami
+      ansible.builtin.set_fact:
+        aws_instance_ami: >
+          {{ (vm_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
+      when: aws_instance_ami is not defined
+
+    - name: Create instance
+      amazon.aws.ec2_instance:
+        filters:
+          "tag:Name": "{{ vm_name }}"
+        network:
+          assign_public_ip: true
+          delete_on_termination: true
+        tenancy: "{{ tenancy }}"
+        key_name: "{{ aws_keypair_name }}"
+        instance_type: "{{ aws_instance_size }}"
+        image_id: "{{ aws_instance_ami | trim }}"
+        region: "{{ aws_region }}"
+        security_group: "{{ aws_securitygroup_name }}"
+        tags:
+          Name: "{{ vm_name }}"
+          blueprint: "{{ vm_blueprint }}"
+          environment: "{{ vm_environment }}"
+          deployment: "{{ vm_deployment }}"
+          owner: "{{ vm_owner }}"
+          purpose: "{{ vm_purpose }}"
+          ansible-role: create_vm
+          ansible-collection: aws.infrastructure_config_demos
+        wait: "{{ aws_ec2_wait }}"
+        vpc_subnet_id: "{{ aws_subnet_id }}"
+        user_data: "{{ lookup('template', aws_userdata_template + '.j2', template_vars=dict(vm_name=vm_name)) }}"
+      register: aws_ec2_instance
+
+    - name: Output the IP of new VM
+      ansible.builtin.debug:
+        msg:
+          - "Public IP for new instance: {{ aws_ec2_instance.instances[0].public_ip_address | default('') }}"
+          - "Private IP for new instance: {{ aws_ec2_instance.instances[0].private_ip_address | default('') }}"
+      when: aws_ec2_instance.instances is defined and aws_ec2_instance.instances | length > 0
+
+    - name: Set stats for Controller of new VM
+      ansible.builtin.set_stats:
+        data:
+          priv_network_private_ip: "{{ aws_ec2_instance.instances[0].private_ip_address | default('') }}"
+          public_ip: "{{ aws_ec2_instance.instances[0].public_ip_address | default('') }}"
+      when: aws_ec2_instance.instances is defined and aws_ec2_instance.instances | length > 0

--- a/roles/create_vm/tasks/main.yml
+++ b/roles/create_vm/tasks/main.yml
@@ -1,0 +1,107 @@
+---
+
+- name: Check if the VM is already provisioned
+  amazon.aws.ec2_instance_info:
+    filters:
+      "tag:Name": "{{ vm_name }}"
+      "tag:blueprint": "{{ vm_blueprint }}"
+      "tag:environment": "{{ vm_environment }}"
+      "tag:deployment": "{{ vm_deployment }}"
+      "tag:owner": "{{ vm_owner }}"
+      "tag:purpose": "{{ vm_purpose }}"
+      "tag:ansible-role": create_vm
+      "tag:ansible-collection": aws.infrastructure_config_demos
+      instance-state-name:
+        - pending
+        - running
+        - shutting-down
+        - stopping
+        - stopped
+    region: "{{ aws_region }}"
+  register: existing_vm
+
+- name: Output the IP of existing VM
+  ansible.builtin.debug:
+    msg: 
+     - "Public IP for new instance: {{ existing_vm.instances[0].public_ip_address }}"
+     - "Private IP for new instance: {{ existing_vm.instances[0].private_ip_address }}"
+  when: existing_vm.instances is defined and existing_vm.instances | length > 0
+
+- name: Set stats for Controller of existing VM
+  ansible.builtin.set_stats:
+    data:
+      priv_network_private_ip: "{{ existing_vm.instances[0].private_ip_address }}"
+      public_ip: "{{ existing_vm.instances[0].public_ip_address }}"
+  when: existing_vm.instances is defined and existing_vm.instances | length > 0
+
+- block:
+  - name: Get subnet info
+    amazon.aws.ec2_vpc_subnet_info:
+      region: "{{ aws_region }}"
+      filters:
+        "tag:Name": "{{ aws_vpc_subnet_name }}"
+    register: aws_subnet
+    when: aws_subnet_id is not defined
+  
+  - name: Save subnet id
+    set_fact:
+      aws_subnet_id: "{{ aws_subnet.subnets|map(attribute='id')| list | last }}"
+    when: aws_subnet_id is not defined
+  
+  - name: Find ami
+    amazon.aws.ec2_ami_info:
+      region: "{{ aws_region }}"
+      owners: "{{ aws_image_owners | default(omit)}}"
+      filters:
+        name: "{{ aws_image_filter }}"
+        architecture: "{{ aws_image_architecture | default(omit) }}"
+    register: vm_amis
+    when: aws_instance_ami is not defined
+  
+  - name: Save ami
+    set_fact:
+      aws_instance_ami: >
+        {{ (vm_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
+    when: aws_instance_ami is not defined
+
+  - name: Create instance
+    amazon.aws.ec2_instance:
+      filters:
+        "tag:Name": "{{ vm_name }}"
+      network:
+        assign_public_ip: yes
+        delete_on_termination: true
+      tenancy: "{{ tenancy }}"
+      key_name: "{{ aws_keypair_name }}"
+      instance_type: "{{ aws_instance_size }}"
+      image_id: "{{ aws_instance_ami | trim }}"
+      region: "{{ aws_region }}"
+      security_group: "{{ aws_securitygroup_name }}"
+      tags:
+        Name: "{{ vm_name }}"
+        blueprint: "{{ vm_blueprint }}"
+        environment: "{{ vm_environment }}"
+        deployment: "{{ vm_deployment }}"
+        owner: "{{ vm_owner }}"
+        purpose: "{{ vm_purpose }}"
+        ansible-role: create_vm
+        ansible-collection: aws.infrastructure_config_demos
+      wait: "{{ aws_ec2_wait }}"
+      vpc_subnet_id: "{{ aws_subnet_id }}"
+      user_data: "{{ lookup('template', aws_userdata_template+'.j2', template_vars=dict(vm_name=vm_name)) }}"
+    register: aws_ec2_instance
+
+  - name: Output the IP of new VM
+    ansible.builtin.debug:
+      msg:
+        - "Public IP for new instance: {{ aws_ec2_instance.instances[0].public_ip_address | default('') }}"
+        - "Private IP for new instance: {{ aws_ec2_instance.instances[0].private_ip_address | default('') }}"
+    when: aws_ec2_instance.instances is defined and aws_ec2_instance.instances | length > 0
+
+  - name: Set stats for Controller of new VM
+    ansible.builtin.set_stats:
+      data:
+        priv_network_private_ip: "{{ aws_ec2_instance.instances[0].private_ip_address | default('') }}"
+        public_ip: "{{ aws_ec2_instance.instances[0].public_ip_address | default('') }}"
+    when: aws_ec2_instance.instances is defined and aws_ec2_instance.instances | length > 0
+  when: existing_vm.instances | length == 0

--- a/roles/create_vm/templates/aws_windows_userdata.j2
+++ b/roles/create_vm/templates/aws_windows_userdata.j2
@@ -1,0 +1,29 @@
+<powershell>
+# Disable .Net Optimization Service
+Get-ScheduledTask *ngen* | Disable-ScheduledTask
+
+# Disable Windows Auto Updates
+# https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/troubleshooting-windows-instances.html#high-cpu-issue
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update" /v AUOptions /t REG_DWORD /d 1 /f
+net stop wuauserv
+net start wuauserv
+
+# Remove policies stopping us from enabling WinRM
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /f
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /f
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v DisableRunAs /f
+
+# Disable Windows Defender Monitoring
+Set-MpPreference -DisableRealtimeMonitoring $true
+
+# Enable WinRM
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile C:\ConfigureRemotingForAnsible.ps1
+C:\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP
+
+# add ec2-user
+$Password = ConvertTo-SecureString {{ ansible_password }} -AsPlainText -Force
+New-LocalUser -Name "ec2-user" -Description "Ansible Service Account" -Password $Password
+Add-LocalGroupMember -Group "Administrators" -Member "ec2-user"
+
+Rename-Computer -NewName {{ vm_name }} -Force -Restart
+</powershell>

--- a/vm_blueprints/rhel7.yml
+++ b/vm_blueprints/rhel7.yml
@@ -1,0 +1,5 @@
+---
+aws_image_owners: 309956199498
+aws_instance_size: t2.medium
+aws_image_architecture: x86_64
+aws_image_filter: 'RHEL-7.9_HVM*'

--- a/vm_blueprints/rhel8.yml
+++ b/vm_blueprints/rhel8.yml
@@ -1,0 +1,5 @@
+---
+aws_image_owners: 309956199498
+aws_instance_size: t3.micro
+aws_image_architecture: x86_64
+aws_image_filter: 'RHEL-8*HVM-*Hourly*'

--- a/vm_blueprints/rhel9.yml
+++ b/vm_blueprints/rhel9.yml
@@ -1,0 +1,5 @@
+---
+aws_image_owners: 309956199498
+aws_instance_size: t3.micro
+aws_image_architecture: x86_64
+aws_image_filter: 'RHEL-9*HVM-*Hourly*'

--- a/vm_blueprints/windows_core.yml
+++ b/vm_blueprints/windows_core.yml
@@ -1,0 +1,4 @@
+---
+aws_image_filter: 'Windows_Server-2019-English-Core-Base*'
+aws_instance_size: t3.medium
+aws_userdata_template: aws_windows_userdata

--- a/vm_blueprints/windows_full.yml
+++ b/vm_blueprints/windows_full.yml
@@ -1,0 +1,4 @@
+---
+aws_image_filter: 'Windows_Server-2019-English-Full-Base*'
+aws_instance_size: t3.medium
+aws_userdata_template: aws_windows_userdata


### PR DESCRIPTION
This PR migrates the create VM playbook to a role and adds the capability to define multiple types of machines to build using "blueprint" variable files.

Also included is a delete VM playbook that uses dynamic inventory variables to delete machines by inventory_hostname