### PR TITLE
Malformed AMI Fix

### DIFF
--- a/roles/manage_direct_peered_networks/tasks/create.yml
+++ b/roles/manage_direct_peered_networks/tasks/create.yml
@@ -291,14 +291,14 @@
     - name: Select DMZ instance ami
       ansible.builtin.set_fact:
         dmz_instance_ami: >
-          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim }}
+          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: dmz_instance_ami is not defined
 
     - name: Provision an SSH tunnel VM in the DMZ
       amazon.aws.ec2_instance:
         count: 1
         image:
-          id: "{{ dmz_instance_ami }}"
+          id: "{{ dmz_instance_ami | trim }}"
         instance_type: "{{ dmz_instance_type }}"
         key_name: "{{ dmz_ssh_key_name }}"
         name: "{{ dmz_instance_name }}"
@@ -387,14 +387,14 @@
     - name: Select private network instance ami
       ansible.builtin.set_fact:
         priv_network_instance_ami: >
-          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim }}
+          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: priv_network_instance_ami is not defined
 
     - name: Provision a test VM in the private network
       amazon.aws.ec2_instance:
         count: 1
         image:
-          id: "{{ priv_network_instance_ami }}"
+          id: "{{ priv_network_instance_ami | trim }}"
         instance_type: "{{ priv_network_instance_type }}"
         key_name: "{{ priv_network_ssh_key_name }}"
         name: "{{ priv_network_instance_name }}"

--- a/roles/manage_transit_peered_networks/tasks/create.yml
+++ b/roles/manage_transit_peered_networks/tasks/create.yml
@@ -336,14 +336,14 @@
     - name: Select DMZ instance ami
       ansible.builtin.set_fact:
         dmz_instance_ami: >
-          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim }}
+          {{ (dmz_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: dmz_instance_ami is not defined
 
     - name: Provision an SSH tunnel VM in the DMZ
       amazon.aws.ec2_instance:
         count: 1
         image:
-          id: "{{ dmz_instance_ami }}"
+          id: "{{ dmz_instance_ami | trim }}"
         instance_type: "{{ dmz_instance_type }}"
         key_name: "{{ dmz_ssh_key_name }}"
         name: "{{ dmz_instance_name }}"
@@ -432,14 +432,14 @@
     - name: Select private network instance ami
       ansible.builtin.set_fact:
         priv_network_instance_ami: >
-          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id | trim }}
+          {{ (private_network_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
       when: priv_network_instance_ami is not defined
 
     - name: Provision a test VM in the private network
       amazon.aws.ec2_instance:
         count: 1
         image:
-          id: "{{ priv_network_instance_ami }}"
+          id: "{{ priv_network_instance_ami | trim }}"
         instance_type: "{{ priv_network_instance_type }}"
         key_name: "{{ priv_network_ssh_key_name }}"
         name: "{{ priv_network_instance_name }}"


### PR DESCRIPTION
Fixes Issue #5.

For some reason, the trim filter on the ami lookup leaves a trialing `\n` which results in a malformed ami error. Moving the trim to the ec2_instance module fixes this issue. 