### PR TITLE
Fix the Delete VM playbook

### DIFF
--- a/playbook_delete_vm.yml
+++ b/playbook_delete_vm.yml
@@ -13,8 +13,9 @@
     - name: Check if a demo VM is already provisioned
       amazon.aws.ec2_instance_info:
         filters:
-          "tag:Name": demo_vm
-          "tag:=owner": ansible
+          "tag:deployment": default
+#          "tag:Name": demo_vm
+#          "tag:=owner": ansible
           "tag:purpose": demo
           "tag:ansible-role": create_vm
           "tag:ansible-collection": aws.infrastructure_config_demos

--- a/playbook_delete_vm.yml
+++ b/playbook_delete_vm.yml
@@ -29,7 +29,7 @@
 
     - name: Display the exisiting vm
       ansible.builtin.debug:
-        var: existing_vm
+        msg: " {{ existing_vm }}"
 
     - name: Delete VM
       amazon.aws.ec2_instance:

--- a/playbook_delete_vm.yml
+++ b/playbook_delete_vm.yml
@@ -14,8 +14,6 @@
       amazon.aws.ec2_instance_info:
         filters:
           "tag:deployment": default
-#          "tag:Name": demo_vm
-#          "tag:=owner": ansible
           "tag:purpose": demo
           "tag:ansible-role": create_vm
           "tag:ansible-collection": aws.infrastructure_config_demos
@@ -27,10 +25,6 @@
             - stopped
         region: "{{ aws_region }}"
       register: existing_vm
-
-    - name: Display the exisiting vm
-      ansible.builtin.debug:
-        msg: "{{ existing_vm }}"
 
     - name: Delete VM
       amazon.aws.ec2_instance:

--- a/playbook_delete_vm.yml
+++ b/playbook_delete_vm.yml
@@ -29,7 +29,7 @@
 
     - name: Display the exisiting vm
       ansible.builtin.debug:
-        msg: " {{ existing_vm }}"
+        msg: "{{ existing_vm }}"
 
     - name: Delete VM
       amazon.aws.ec2_instance:

--- a/playbook_delete_vm.yml
+++ b/playbook_delete_vm.yml
@@ -13,9 +13,10 @@
     - name: Check if a demo VM is already provisioned
       amazon.aws.ec2_instance_info:
         filters:
-          "tag:deployment": ansible
-          "tag:purpose": create-vm-demo
-          "tag:ansible-role": none
+          "tag:Name": demo_vm
+          "tag:=owner": ansible
+          "tag:purpose": demo
+          "tag:ansible-role": create_vm
           "tag:ansible-collection": aws.infrastructure_config_demos
           instance-state-name:
             - pending

--- a/playbook_delete_vm.yml
+++ b/playbook_delete_vm.yml
@@ -27,6 +27,10 @@
         region: "{{ aws_region }}"
       register: existing_vm
 
+    - name: Display the exisiting vm
+      ansible.builtin.debug:
+        var: existing_vm
+
     - name: Delete VM
       amazon.aws.ec2_instance:
         instance_ids:


### PR DESCRIPTION
The Delete VM playbook had stopped working after the work that was done on the Create VM role.  I fixed it based on the changes, and it now works.  Thanks.