### PR TITLE
added default owner for windows AMIs

### DIFF
--- a/playbooks/vars/vm_blueprints/windows_core.yml
+++ b/playbooks/vars/vm_blueprints/windows_core.yml
@@ -1,4 +1,6 @@
 ---
+create_vm_aws_image_owners:
+  - amazon
 create_vm_aws_image_filter: 'Windows_Server-2019-English-Core-Base*'
 create_vm_aws_instance_size: t3.medium
 create_vm_aws_userdata_template: aws_windows_userdata

--- a/playbooks/vars/vm_blueprints/windows_full.yml
+++ b/playbooks/vars/vm_blueprints/windows_full.yml
@@ -1,4 +1,6 @@
 ---
+create_vm_aws_image_owners:
+  - amazon
 create_vm_aws_image_filter: 'Windows_Server-2019-English-Full-Base*'
 create_vm_aws_instance_size: t3.medium
 create_vm_aws_userdata_template: aws_windows_userdata


### PR DESCRIPTION
currently a windows AMI from the marketplace that matches the search string is newer than the windows AMI managed by amazon so instances are getting built with it instead.  this change pins the AMI search to those owned by the amazon owner alias.